### PR TITLE
Replace assert with AWS_FATAL_ASSERT in aws_array_list_swap function

### DIFF
--- a/include/aws/common/array_list.h
+++ b/include/aws/common/array_list.h
@@ -185,7 +185,7 @@ AWS_STATIC_IMPL
 int aws_array_list_set_at(struct aws_array_list *AWS_RESTRICT list, const void *val, size_t index);
 
 /**
- * Swap elements at the specified indices.
+ * Swap elements at the specified indices, which must be within the bounds of the array.
  */
 AWS_COMMON_API
 void aws_array_list_swap(struct aws_array_list *AWS_RESTRICT list, size_t a, size_t b);

--- a/source/array_list.c
+++ b/source/array_list.c
@@ -163,14 +163,14 @@ static void aws_array_list_mem_swap(void *AWS_RESTRICT item1, void *AWS_RESTRICT
 }
 
 void aws_array_list_swap(struct aws_array_list *AWS_RESTRICT list, size_t a, size_t b) {
-    assert(a < list->length);
-    assert(b < list->length);
+    AWS_FATAL_ASSERT(a < list->length);
+    AWS_FATAL_ASSERT(b < list->length);
     if (a == b) {
         return;
     }
 
     void *item1 = NULL, *item2 = NULL;
-    aws_array_list_get_at_ptr(list, &item1, a);
-    aws_array_list_get_at_ptr(list, &item2, b);
+    AWS_FATAL_ASSERT(!aws_array_list_get_at_ptr(list, &item1, a));
+    AWS_FATAL_ASSERT(!aws_array_list_get_at_ptr(list, &item2, b));
     aws_array_list_mem_swap(item1, item2, list->item_size);
 }


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

*Description of changes:*

Replace `assert` with `AWS_FATAL_ASSERT` in `aws_array_list_swap function`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
