### PR TITLE
Replace all assert statements with AWS_FATAL_ASSERT in aws_array_list

### DIFF
--- a/include/aws/common/array_list.inl
+++ b/include/aws/common/array_list.inl
@@ -50,7 +50,7 @@ int aws_array_list_init_dynamic(
 #endif
         list->current_size = allocation_size;
     }
-    assert(list->current_size == 0 || list->data);
+    AWS_FATAL_ASSERT(list->current_size == 0 || list->data);
 
     return AWS_OP_SUCCESS;
 }
@@ -61,9 +61,9 @@ void aws_array_list_init_static(
     void *raw_array,
     size_t item_count,
     size_t item_size) {
-    assert(raw_array);
-    assert(item_count);
-    assert(item_size);
+    AWS_FATAL_ASSERT(raw_array);
+    AWS_FATAL_ASSERT(item_count);
+    AWS_FATAL_ASSERT(item_size);
 
     list->alloc = NULL;
 
@@ -154,7 +154,7 @@ AWS_STATIC_IMPL
 int aws_array_list_pop_back(struct aws_array_list *AWS_RESTRICT list) {
     if (aws_array_list_length(list) > 0) {
 
-        assert(list->data);
+        AWS_FATAL_ASSERT(list->data);
 
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
@@ -180,10 +180,10 @@ AWS_STATIC_IMPL
 void aws_array_list_swap_contents(
     struct aws_array_list *AWS_RESTRICT list_a,
     struct aws_array_list *AWS_RESTRICT list_b) {
-    assert(list_a->alloc);
-    assert(list_a->alloc == list_b->alloc);
-    assert(list_a->item_size == list_b->item_size);
-    assert(list_a != list_b);
+    AWS_FATAL_ASSERT(list_a->alloc);
+    AWS_FATAL_ASSERT(list_a->alloc == list_b->alloc);
+    AWS_FATAL_ASSERT(list_a->item_size == list_b->item_size);
+    AWS_FATAL_ASSERT(list_a != list_b);
 
     struct aws_array_list tmp = *list_a;
     *list_a = *list_b;
@@ -192,7 +192,7 @@ void aws_array_list_swap_contents(
 
 AWS_STATIC_IMPL
 size_t aws_array_list_capacity(const struct aws_array_list *AWS_RESTRICT list) {
-    assert(list->item_size);
+    AWS_FATAL_ASSERT(list->item_size);
     return list->current_size / list->item_size;
 }
 
@@ -202,7 +202,7 @@ size_t aws_array_list_length(const struct aws_array_list *AWS_RESTRICT list) {
      * This assert teaches clang-tidy and friends that list->data cannot be null in a non-empty
      * list.
      */
-    assert(!list->length || list->data);
+    AWS_FATAL_ASSERT(!list->length || list->data);
 
     return list->length;
 }
@@ -251,7 +251,7 @@ int aws_array_list_set_at(struct aws_array_list *AWS_RESTRICT list, const void *
         }
     }
 
-    assert(list->data);
+    AWS_FATAL_ASSERT(list->data);
 
     memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
 

--- a/include/aws/common/atomics_gnu_old.inl
+++ b/include/aws/common/atomics_gnu_old.inl
@@ -55,7 +55,7 @@ static inline void aws_atomic_private_barrier_after(enum aws_memory_order order)
  */
 AWS_STATIC_IMPL
 void aws_atomic_init_int(volatile struct aws_atomic_var *var, size_t n) {
-    var->u.intval = n;
+    AWS_ATOMIC_VAR_INTVAL(var) = n;
 }
 
 /**
@@ -64,7 +64,7 @@ void aws_atomic_init_int(volatile struct aws_atomic_var *var, size_t n) {
  */
 AWS_STATIC_IMPL
 void aws_atomic_init_ptr(volatile struct aws_atomic_var *var, void *p) {
-    var->u.ptrval = p;
+    AWS_ATOMIC_VAR_PTRVAL(var) = p;
 }
 
 /**
@@ -74,7 +74,7 @@ AWS_STATIC_IMPL
 size_t aws_atomic_load_int_explicit(volatile const struct aws_atomic_var *var, enum aws_memory_order memory_order) {
     aws_atomic_private_barrier_before(memory_order);
 
-    size_t retval = var->u.intval;
+    size_t retval = AWS_ATOMIC_VAR_INTVAL(var);
 
     /* Release barriers are not permitted for loads, so we just do a compiler barrier here */
     aws_atomic_private_compiler_barrier();
@@ -89,7 +89,7 @@ AWS_STATIC_IMPL
 void *aws_atomic_load_ptr_explicit(volatile const struct aws_atomic_var *var, enum aws_memory_order memory_order) {
     aws_atomic_private_barrier_before(memory_order);
 
-    void *retval = var->u.ptrval;
+    void *retval = AWS_ATOMIC_VAR_PTRVAL(var);
 
     /* Release barriers are not permitted for loads, so we just do a compiler barrier here */
     aws_atomic_private_compiler_barrier();
@@ -105,7 +105,7 @@ void aws_atomic_store_int_explicit(volatile struct aws_atomic_var *var, size_t n
     /* Acquire barriers are not permitted for stores, so just do a compiler barrier before */
     aws_atomic_private_compiler_barrier();
 
-    var->u.intval = n;
+    AWS_ATOMIC_VAR_INTVAL(var) = n;
 
     aws_atomic_private_barrier_after(memory_order);
 }
@@ -118,7 +118,7 @@ void aws_atomic_store_ptr_explicit(volatile struct aws_atomic_var *var, void *p,
     /* Acquire barriers are not permitted for stores, so just do a compiler barrier before */
     aws_atomic_private_compiler_barrier();
 
-    var->u.ptrval = p;
+    AWS_ATOMIC_VAR_PTRVAL(var) = p;
 
     aws_atomic_private_barrier_after(memory_order);
 }
@@ -141,8 +141,8 @@ size_t aws_atomic_exchange_int_explicit(
 
     size_t oldval;
     do {
-        oldval = var->u.intval;
-    } while (!__sync_bool_compare_and_swap(&var->u.intval, oldval, n));
+        oldval = AWS_ATOMIC_VAR_INTVAL(var);
+    } while (!__sync_bool_compare_and_swap(&AWS_ATOMIC_VAR_INTVAL(var), oldval, n));
 
     /* __sync_bool_compare_and_swap implies a full barrier */
 
@@ -166,8 +166,8 @@ void *aws_atomic_exchange_ptr_explicit(
      */
     void *oldval;
     do {
-        oldval = var->u.ptrval;
-    } while (!__sync_bool_compare_and_swap(&var->u.ptrval, oldval, p));
+        oldval = AWS_ATOMIC_VAR_PTRVAL(var);
+    } while (!__sync_bool_compare_and_swap(&AWS_ATOMIC_VAR_PTRVAL(var), oldval, p));
 
     /* __sync_bool_compare_and_swap implies a full barrier */
 
@@ -187,9 +187,9 @@ bool aws_atomic_compare_exchange_int_explicit(
     enum aws_memory_order order_success,
     enum aws_memory_order order_failure) {
 
-    bool result = __sync_bool_compare_and_swap(&var->u.intval, *expected, desired);
+    bool result = __sync_bool_compare_and_swap(&AWS_ATOMIC_VAR_INTVAL(var), *expected, desired);
     if (!result) {
-        *expected = var->u.intval;
+        *expected = AWS_ATOMIC_VAR_INTVAL(var);
     }
 
     return result;
@@ -208,9 +208,9 @@ bool aws_atomic_compare_exchange_ptr_explicit(
     enum aws_memory_order order_success,
     enum aws_memory_order order_failure) {
 
-    bool result = __sync_bool_compare_and_swap(&var->u.ptrval, *expected, desired);
+    bool result = __sync_bool_compare_and_swap(&AWS_ATOMIC_VAR_PTRVAL(var), *expected, desired);
     if (!result) {
-        *expected = var->u.ptrval;
+        *expected = AWS_ATOMIC_VAR_PTRVAL(var);
     }
 
     return result;
@@ -221,7 +221,7 @@ bool aws_atomic_compare_exchange_ptr_explicit(
  */
 AWS_STATIC_IMPL
 size_t aws_atomic_fetch_add_explicit(volatile struct aws_atomic_var *var, size_t n, enum aws_memory_order order) {
-    return __sync_fetch_and_add(&var->u.intval, n);
+    return __sync_fetch_and_add(&AWS_ATOMIC_VAR_INTVAL(var), n);
 }
 
 /**
@@ -229,7 +229,7 @@ size_t aws_atomic_fetch_add_explicit(volatile struct aws_atomic_var *var, size_t
  */
 AWS_STATIC_IMPL
 size_t aws_atomic_fetch_sub_explicit(volatile struct aws_atomic_var *var, size_t n, enum aws_memory_order order) {
-    return __sync_fetch_and_sub(&var->u.intval, n);
+    return __sync_fetch_and_sub(&AWS_ATOMIC_VAR_INTVAL(var), n);
 }
 
 /**
@@ -237,7 +237,7 @@ size_t aws_atomic_fetch_sub_explicit(volatile struct aws_atomic_var *var, size_t
  */
 AWS_STATIC_IMPL
 size_t aws_atomic_fetch_or_explicit(volatile struct aws_atomic_var *var, size_t n, enum aws_memory_order order) {
-    return __sync_fetch_and_or(&var->u.intval, n);
+    return __sync_fetch_and_or(&AWS_ATOMIC_VAR_INTVAL(var), n);
 }
 
 /**
@@ -245,7 +245,7 @@ size_t aws_atomic_fetch_or_explicit(volatile struct aws_atomic_var *var, size_t 
  */
 AWS_STATIC_IMPL
 size_t aws_atomic_fetch_and_explicit(volatile struct aws_atomic_var *var, size_t n, enum aws_memory_order order) {
-    return __sync_fetch_and_and(&var->u.intval, n);
+    return __sync_fetch_and_and(&AWS_ATOMIC_VAR_INTVAL(var), n);
 }
 
 /**
@@ -253,7 +253,7 @@ size_t aws_atomic_fetch_and_explicit(volatile struct aws_atomic_var *var, size_t
  */
 AWS_STATIC_IMPL
 size_t aws_atomic_fetch_xor_explicit(volatile struct aws_atomic_var *var, size_t n, enum aws_memory_order order) {
-    return __sync_fetch_and_xor(&var->u.intval, n);
+    return __sync_fetch_and_xor(&AWS_ATOMIC_VAR_INTVAL(var), n);
 }
 
 /**

--- a/source/array_list.c
+++ b/source/array_list.c
@@ -47,8 +47,8 @@ int aws_array_list_shrink_to_fit(struct aws_array_list *AWS_RESTRICT list) {
 }
 
 int aws_array_list_copy(const struct aws_array_list *AWS_RESTRICT from, struct aws_array_list *AWS_RESTRICT to) {
-    assert(from->item_size == to->item_size);
-    assert(from->data);
+    AWS_FATAL_ASSERT(from->item_size == to->item_size);
+    AWS_FATAL_ASSERT(from->data);
 
     size_t copy_size;
     if (aws_mul_size_checked(from->length, from->item_size, &copy_size)) {
@@ -142,8 +142,8 @@ int aws_array_list_ensure_capacity(struct aws_array_list *AWS_RESTRICT list, siz
 static void aws_array_list_mem_swap(void *AWS_RESTRICT item1, void *AWS_RESTRICT item2, size_t item_size) {
     enum { SLICE = 128 };
 
-    assert(item1);
-    assert(item2);
+    AWS_FATAL_ASSERT(item1);
+    AWS_FATAL_ASSERT(item2);
 
     /* copy SLICE sized bytes at a time */
     size_t slice_count = item_size / SLICE;


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

*Description of changes:*

We need to update array_list implementation to use `AWS_FATAL_ASSERT` instead of the common `assert`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
