### PR TITLE
memory safety proof of aws_byte_buf_append_dynamic

### DIFF
--- a/.cbmc-batch/jobs/aws_byte_buf_append_dynamic/Makefile
+++ b/.cbmc-batch/jobs/aws_byte_buf_append_dynamic/Makefile
@@ -1,0 +1,29 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+CBMC_UNWINDSET =
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/stubs/error.c
+DEPENDENCIES += $(HELPERDIR)/stubs/memcpy_override_no_op.c
+DEPENDENCIES += $(SRCDIR)/source/byte_buf.c
+DEPENDENCIES += $(SRCDIR)/source/common.c
+
+ENTRY = aws_byte_buf_append_dynamic_harness
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_byte_buf_append_dynamic/aws_byte_buf_append_dynamic_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_append_dynamic/aws_byte_buf_append_dynamic_harness.c
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/byte_buf.h>
+#include <proof_helpers/make_common_data_structures.h>
+
+bool is_bounded_byte_buf(struct aws_byte_buf *buf, size_t max_size) {
+    return buf->capacity == max_size;
+}
+
+bool is_valid_byte_buf(struct aws_byte_buf *buf) {
+    return (buf->len <= buf->capacity)
+    && (buf->allocator == NULL || buf->allocator == can_fail_allocator());
+    /* TODO: once we can check allocated size of buffer, also assert that
+     * buf->capacity <= __CPROVER_buffer_size(buf->buffer);
+     */
+}
+
+void ensure_bute_buf_has_allocated_buffer_member(struct aws_byte_buf *buf) {
+    __CPROVER_assume(buf->capacity <= MAX_MALLOC);
+    buf->buffer = malloc(sizeof(*(buf->buffer)) * buf->capacity);
+}
+
+bool is_bounded_byte_cursor(struct aws_byte_cursor *cursor, size_t max_size) {
+    return cursor->len <= max_size;
+}
+
+bool is_valid_byte_cursor(struct aws_byte_cursor *cursor) {
+    return (cursor->ptr == NULL && cursor->len == 0)
+    || (cursor->ptr != NULL && cursor->len != 0);
+    /* TODO: once we can check allocated size of buffer, also assert that
+     * cursor->len <= __CPROVER_buffer_size(cursor->ptr);
+     */
+}
+
+void ensure_byte_cursor_has_allocated_buffer_member(struct aws_byte_cursor *cursor) {
+    __CPROVER_assume(cursor->len <= MAX_MALLOC);
+    cursor->ptr = malloc(cursor->len);
+}
+
+void aws_byte_buf_append_dynamic_harness() {
+    /* new proof style */
+    struct aws_byte_buf to;
+    __CPROVER_assume(is_bounded_byte_buf(&to, MAX_MALLOC));
+    __CPROVER_assume(is_valid_byte_buf(&to));
+    ensure_bute_buf_has_allocated_buffer_member(&to);
+
+    struct aws_byte_cursor from;
+    __CPROVER_assume(is_bounded_byte_cursor(&from, MAX_MALLOC));
+    __CPROVER_assume(is_valid_byte_cursor(&from));
+    ensure_byte_cursor_has_allocated_buffer_member(&from);
+
+    aws_byte_buf_append_dynamic(&to, &from);
+
+    assert(is_valid_byte_buf(&to));
+    assert(is_valid_byte_cursor(&from));
+}

--- a/.cbmc-batch/jobs/aws_byte_buf_append_dynamic/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_byte_buf_append_dynamic/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--function;aws_byte_buf_append_harness"
+goto: aws_byte_buf_append_harness.goto
+expected: "SUCCESSFUL"

--- a/include/aws/common/byte_buf.h
+++ b/include/aws/common/byte_buf.h
@@ -290,6 +290,17 @@ AWS_COMMON_API
 int aws_byte_buf_append(struct aws_byte_buf *to, const struct aws_byte_cursor *from);
 
 /**
+ * Copies from to to. If to is too small, the buffer will be grown appropriately and
+ * the old contents copied to, before the new contents are appended.
+ *
+ * If the grow fails (overflow or OOM), then an error will be returned.
+ *
+ * from and to may be the same buffer, permitting copying a buffer into itself.
+ */
+AWS_COMMON_API
+int aws_byte_buf_append_dynamic(struct aws_byte_buf *to, const struct aws_byte_cursor *from);
+
+/**
  * Concatenates a variable number of struct aws_byte_buf * into destination.
  * Number of args must be greater than 1. If dest is too small,
  * AWS_ERROR_DEST_COPY_TOO_SMALL will be returned. dest->len will contain the

--- a/source/byte_buf.c
+++ b/source/byte_buf.c
@@ -380,6 +380,75 @@ int aws_byte_buf_append(struct aws_byte_buf *to, const struct aws_byte_cursor *f
     return AWS_OP_SUCCESS;
 }
 
+int aws_byte_buf_append_dynamic(struct aws_byte_buf *to, const struct aws_byte_cursor *from) {
+    assert(from->ptr);
+    assert(to->buffer);
+
+    if (to->capacity - to->len < from->len) {
+        /*
+         * We don't have size_t math so use 64 bits for overflow checking.
+         * Then do a final check before allocating to verify that the computed
+         * new capacity is actually containable within the platform's size_t type.
+         *
+         * If size_t ever exceeds 64 bits, this won't be valid
+         */
+
+        /*
+         * NewCapacity = Max(OldCapacity * 1.5, OldCapacity + MissingCapacity)
+         */
+        uint64_t missing_capacity = (uint64_t)(from->len - (to->capacity - to->len));
+        uint64_t new_capacity = 0;
+        if (aws_add_u64_checked(to->capacity, missing_capacity, &new_capacity)) {
+            return AWS_OP_ERR;
+        }
+
+        uint64_t growth_capacity = 0;
+        if (aws_add_u64_checked(to->capacity, to->capacity / 2, &growth_capacity)) {
+            return AWS_OP_ERR;
+        }
+
+        if (new_capacity < growth_capacity) {
+            new_capacity = growth_capacity;
+        }
+
+        if (new_capacity > SIZE_MAX) {
+            return aws_raise_error(AWS_ERROR_OVERFLOW_DETECTED);
+        }
+
+        uint8_t *new_buffer = aws_mem_acquire(to->allocator, (size_t)new_capacity);
+        if (new_buffer == NULL) {
+            return AWS_OP_ERR;
+        }
+
+        /*
+         * Copy old buffer -> new buffer
+         */
+        memcpy(new_buffer, to->buffer, to->len);
+
+        /*
+         * Copy what we actually wanted to append in the first place
+         */
+        memcpy(new_buffer + to->len, from->ptr, from->len);
+
+        /*
+         * Get rid of the old buffer
+         */
+        aws_mem_release(to->allocator, to->buffer);
+
+        /*
+         * Switch to the new buffer
+         */
+        to->buffer = new_buffer;
+        to->capacity = (size_t)new_capacity;
+    } else {
+        memcpy(to->buffer + to->len, from->ptr, from->len);
+    }
+
+    to->len += from->len;
+
+    return AWS_OP_SUCCESS;
+}
+
 struct aws_byte_cursor aws_byte_cursor_right_trim_pred(
     const struct aws_byte_cursor *source,
     aws_byte_predicate_fn *predicate) {


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

*Description of changes:*

We now have a "self containing" proof for `aws_byte_buf_append_dynamic` following the new proof style. We are still getting some error paths from this proof, so a discussion would be really helpful.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.