### PR TITLE
Redefine AWS_PRECONDITION and add an explanation on existing preconditions

### DIFF
--- a/include/aws/common/array_list.inl
+++ b/include/aws/common/array_list.inl
@@ -91,7 +91,7 @@ bool aws_array_list_is_valid(const struct aws_array_list *AWS_RESTRICT list) {
 
 AWS_STATIC_IMPL
 void aws_array_list_clean_up(struct aws_array_list *AWS_RESTRICT list) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list));
+    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input array_list [list] must be valid.");
     if (list->alloc && list->data) {
         aws_mem_release(list->alloc, list->data);
     }
@@ -106,7 +106,7 @@ void aws_array_list_clean_up(struct aws_array_list *AWS_RESTRICT list) {
 
 AWS_STATIC_IMPL
 int aws_array_list_push_back(struct aws_array_list *AWS_RESTRICT list, const void *val) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list));
+    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input array_list [list] must be valid.");
     int err_code = aws_array_list_set_at(list, val, aws_array_list_length(list));
 
     if (err_code && aws_last_error() == AWS_ERROR_INVALID_INDEX && !list->alloc) {
@@ -120,7 +120,7 @@ int aws_array_list_push_back(struct aws_array_list *AWS_RESTRICT list, const voi
 
 AWS_STATIC_IMPL
 int aws_array_list_front(const struct aws_array_list *AWS_RESTRICT list, void *val) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list));
+    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input array_list [list] must be valid.");
     if (aws_array_list_length(list) > 0) {
         memcpy(val, list->data, list->item_size);
         AWS_POSTCONDITION(aws_array_list_is_valid(list));
@@ -133,7 +133,7 @@ int aws_array_list_front(const struct aws_array_list *AWS_RESTRICT list, void *v
 
 AWS_STATIC_IMPL
 int aws_array_list_pop_front(struct aws_array_list *AWS_RESTRICT list) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list));
+    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input array_list [list] must be valid.");
     if (aws_array_list_length(list) > 0) {
         aws_array_list_pop_front_n(list, 1);
         AWS_POSTCONDITION(aws_array_list_is_valid(list));
@@ -146,7 +146,7 @@ int aws_array_list_pop_front(struct aws_array_list *AWS_RESTRICT list) {
 
 AWS_STATIC_IMPL
 void aws_array_list_pop_front_n(struct aws_array_list *AWS_RESTRICT list, size_t n) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list));
+    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input array_list [list] must be valid.");
     if (n >= aws_array_list_length(list)) {
         aws_array_list_clear(list);
         AWS_POSTCONDITION(aws_array_list_is_valid(list));
@@ -168,7 +168,7 @@ void aws_array_list_pop_front_n(struct aws_array_list *AWS_RESTRICT list, size_t
 
 AWS_STATIC_IMPL
 int aws_array_list_back(const struct aws_array_list *AWS_RESTRICT list, void *val) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list));
+    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input array_list [list] must be valid.");
     if (aws_array_list_length(list) > 0) {
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
@@ -183,7 +183,7 @@ int aws_array_list_back(const struct aws_array_list *AWS_RESTRICT list, void *va
 
 AWS_STATIC_IMPL
 int aws_array_list_pop_back(struct aws_array_list *AWS_RESTRICT list) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list));
+    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input array_list [list] must be valid.");
     if (aws_array_list_length(list) > 0) {
 
         AWS_FATAL_ASSERT(list->data);
@@ -202,7 +202,7 @@ int aws_array_list_pop_back(struct aws_array_list *AWS_RESTRICT list) {
 
 AWS_STATIC_IMPL
 void aws_array_list_clear(struct aws_array_list *AWS_RESTRICT list) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list));
+    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input array_list [list] must be valid.");
     if (list->data) {
 #ifdef DEBUG_BUILD
         memset(list->data, AWS_ARRAY_LIST_DEBUG_FILL, list->current_size);
@@ -220,8 +220,8 @@ void aws_array_list_swap_contents(
     AWS_FATAL_ASSERT(list_a->alloc == list_b->alloc);
     AWS_FATAL_ASSERT(list_a->item_size == list_b->item_size);
     AWS_FATAL_ASSERT(list_a != list_b);
-    AWS_PRECONDITION(aws_array_list_is_valid(list_a));
-    AWS_PRECONDITION(aws_array_list_is_valid(list_b));
+    AWS_PRECONDITION(aws_array_list_is_valid(list_a), "Input array_list [list_a] must be valid.");
+    AWS_PRECONDITION(aws_array_list_is_valid(list_b), "Input array_list [list_b] must be valid.");
 
     struct aws_array_list tmp = *list_a;
     *list_a = *list_b;
@@ -233,7 +233,7 @@ void aws_array_list_swap_contents(
 AWS_STATIC_IMPL
 size_t aws_array_list_capacity(const struct aws_array_list *AWS_RESTRICT list) {
     AWS_FATAL_ASSERT(list->item_size);
-    AWS_PRECONDITION(aws_array_list_is_valid(list));
+    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input array_list [list] must be valid.");
     size_t capacity = list->current_size / list->item_size;
     AWS_POSTCONDITION(aws_array_list_is_valid(list));
     return capacity;
@@ -246,7 +246,7 @@ size_t aws_array_list_length(const struct aws_array_list *AWS_RESTRICT list) {
      * list.
      */
     AWS_FATAL_ASSERT(!list->length || list->data);
-    AWS_PRECONDITION(aws_array_list_is_valid(list));
+    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input array_list [list] must be valid.");
     size_t len = list->length;
     AWS_POSTCONDITION(aws_array_list_is_valid(list));
     return len;
@@ -254,7 +254,7 @@ size_t aws_array_list_length(const struct aws_array_list *AWS_RESTRICT list) {
 
 AWS_STATIC_IMPL
 int aws_array_list_get_at(const struct aws_array_list *AWS_RESTRICT list, void *val, size_t index) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list));
+    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input array_list [list] must be valid.");
     if (aws_array_list_length(list) > index) {
         memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
         AWS_POSTCONDITION(aws_array_list_is_valid(list));
@@ -266,7 +266,7 @@ int aws_array_list_get_at(const struct aws_array_list *AWS_RESTRICT list, void *
 
 AWS_STATIC_IMPL
 int aws_array_list_get_at_ptr(const struct aws_array_list *AWS_RESTRICT list, void **val, size_t index) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list));
+    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input array_list [list] must be valid.");
     if (aws_array_list_length(list) > index) {
         *val = (void *)((uint8_t *)list->data + (list->item_size * index));
         AWS_POSTCONDITION(aws_array_list_is_valid(list));
@@ -278,7 +278,7 @@ int aws_array_list_get_at_ptr(const struct aws_array_list *AWS_RESTRICT list, vo
 
 AWS_STATIC_IMPL
 int aws_array_list_calc_necessary_size(struct aws_array_list *AWS_RESTRICT list, size_t index, size_t *necessary_size) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list));
+    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input array_list [list] must be valid.");
     size_t index_inc;
     if (aws_add_size_checked(index, 1, &index_inc)) {
         AWS_POSTCONDITION(aws_array_list_is_valid(list));
@@ -295,7 +295,7 @@ int aws_array_list_calc_necessary_size(struct aws_array_list *AWS_RESTRICT list,
 
 AWS_STATIC_IMPL
 int aws_array_list_set_at(struct aws_array_list *AWS_RESTRICT list, const void *val, size_t index) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list));
+    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input array_list [list] must be valid.");
     size_t necessary_size;
     if (aws_array_list_calc_necessary_size(list, index, &necessary_size)) {
         AWS_POSTCONDITION(aws_array_list_is_valid(list));
@@ -330,7 +330,7 @@ int aws_array_list_set_at(struct aws_array_list *AWS_RESTRICT list, const void *
 
 AWS_STATIC_IMPL
 void aws_array_list_sort(struct aws_array_list *AWS_RESTRICT list, aws_array_list_comparator_fn *compare_fn) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list));
+    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input array_list [list] must be valid.");
     if (list->data) {
         qsort(list->data, aws_array_list_length(list), list->item_size, compare_fn);
     }

--- a/include/aws/common/byte_buf.h
+++ b/include/aws/common/byte_buf.h
@@ -481,7 +481,7 @@ AWS_STATIC_IMPL struct aws_byte_buf aws_byte_buf_from_c_str(const char *c_str) {
 }
 
 AWS_STATIC_IMPL struct aws_byte_buf aws_byte_buf_from_array(const void *bytes, size_t len) {
-    AWS_PRECONDITION(AWS_MEM_IS_WRITABLE(bytes, len));
+    AWS_PRECONDITION(AWS_MEM_IS_WRITABLE(bytes, len), "Input array [bytes] must be writable up to [len] bytes.");
     struct aws_byte_buf buf;
     buf.buffer = (len > 0) ? (uint8_t *)bytes : NULL;
     buf.len = len;
@@ -492,7 +492,8 @@ AWS_STATIC_IMPL struct aws_byte_buf aws_byte_buf_from_array(const void *bytes, s
 }
 
 AWS_STATIC_IMPL struct aws_byte_buf aws_byte_buf_from_empty_array(const void *bytes, size_t capacity) {
-    AWS_PRECONDITION(AWS_MEM_IS_WRITABLE(bytes, capacity));
+    AWS_PRECONDITION(
+        AWS_MEM_IS_WRITABLE(bytes, capacity), "Input array [bytes] must be writable up to [capacity] bytes.");
     struct aws_byte_buf buf;
     buf.buffer = (capacity > 0) ? (uint8_t *)bytes : NULL;
     buf.len = 0;

--- a/include/aws/common/common.h
+++ b/include/aws/common/common.h
@@ -117,12 +117,12 @@
  * Violations of the function contracts are undefined behaviour.
  */
 #ifdef CBMC
-#define AWS_PRECONDITION(cond) __CPROVER_assume(cond)
+#define AWS_PRECONDITION(cond, explanation) __CPROVER_precondition((cond), ("Precondition: " explanation))
 #define AWS_POSTCONDITION(cond) AWS_ASSERT(cond)
 #define AWS_MEM_IS_READABLE(base, len) __CPROVER_r_ok((base), (len))
 #define AWS_MEM_IS_WRITABLE(base, len) __CPROVER_w_ok((base), (len))
 #else
-#define AWS_PRECONDITION(cond) AWS_ASSERT(cond)
+#define AWS_PRECONDITION(cond, expl) AWS_ASSERT(cond)
 #define AWS_POSTCONDITION(cond) AWS_ASSERT(cond)
 /* the C runtime does not give a way to check these properties,
  * but we can at least check that the pointer is valid */

--- a/source/array_list.c
+++ b/source/array_list.c
@@ -18,7 +18,7 @@
 #include <stdlib.h> /* qsort */
 
 int aws_array_list_shrink_to_fit(struct aws_array_list *AWS_RESTRICT list) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list));
+    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input array_list [list] must be valid.");
     if (list->alloc) {
         size_t ideal_size;
         if (aws_mul_size_checked(list->length, list->item_size, &ideal_size)) {
@@ -53,8 +53,8 @@ int aws_array_list_shrink_to_fit(struct aws_array_list *AWS_RESTRICT list) {
 int aws_array_list_copy(const struct aws_array_list *AWS_RESTRICT from, struct aws_array_list *AWS_RESTRICT to) {
     AWS_FATAL_ASSERT(from->item_size == to->item_size);
     AWS_FATAL_ASSERT(from->data);
-    AWS_PRECONDITION(aws_array_list_is_valid(from));
-    AWS_PRECONDITION(aws_array_list_is_valid(to));
+    AWS_PRECONDITION(aws_array_list_is_valid(from), "Input array_list [from] must be valid.");
+    AWS_PRECONDITION(aws_array_list_is_valid(to), "Input array_list [to] must be valid.");
 
     size_t copy_size;
     if (aws_mul_size_checked(from->length, from->item_size, &copy_size)) {
@@ -99,7 +99,7 @@ int aws_array_list_copy(const struct aws_array_list *AWS_RESTRICT from, struct a
 }
 
 int aws_array_list_ensure_capacity(struct aws_array_list *AWS_RESTRICT list, size_t index) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list));
+    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input array_list [list] must be valid.");
     size_t necessary_size;
     if (aws_array_list_calc_necessary_size(list, index, &necessary_size)) {
         AWS_POSTCONDITION(aws_array_list_is_valid(list));
@@ -185,7 +185,7 @@ static void aws_array_list_mem_swap(void *AWS_RESTRICT item1, void *AWS_RESTRICT
 void aws_array_list_swap(struct aws_array_list *AWS_RESTRICT list, size_t a, size_t b) {
     AWS_FATAL_ASSERT(a < list->length);
     AWS_FATAL_ASSERT(b < list->length);
-    AWS_PRECONDITION(aws_array_list_is_valid(list));
+    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input array_list [list] must be valid.");
 
     if (a == b) {
         AWS_POSTCONDITION(aws_array_list_is_valid(list));

--- a/source/byte_buf.c
+++ b/source/byte_buf.c
@@ -82,7 +82,7 @@ void aws_byte_buf_reset(struct aws_byte_buf *buf, bool zero_contents) {
 }
 
 void aws_byte_buf_clean_up(struct aws_byte_buf *buf) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(buf));
+    AWS_PRECONDITION(aws_byte_buf_is_valid(buf), "Input byte_buf [buf] must be valid.");
     if (buf->allocator && buf->buffer) {
         aws_mem_release(buf->allocator, (void *)buf->buffer);
     }
@@ -93,7 +93,7 @@ void aws_byte_buf_clean_up(struct aws_byte_buf *buf) {
 }
 
 void aws_byte_buf_secure_zero(struct aws_byte_buf *buf) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(buf));
+    AWS_PRECONDITION(aws_byte_buf_is_valid(buf), "Input byte_buf [buf] must be valid.");
     if (buf->buffer) {
         aws_secure_zero(buf->buffer, buf->capacity);
     }
@@ -102,7 +102,7 @@ void aws_byte_buf_secure_zero(struct aws_byte_buf *buf) {
 }
 
 void aws_byte_buf_clean_up_secure(struct aws_byte_buf *buf) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(buf));
+    AWS_PRECONDITION(aws_byte_buf_is_valid(buf), "Input byte_buf [buf] must be valid.");
     aws_byte_buf_secure_zero(buf);
     aws_byte_buf_clean_up(buf);
     AWS_POSTCONDITION(aws_byte_buf_is_valid(buf));
@@ -421,8 +421,8 @@ bool aws_byte_cursor_eq_c_str_ignore_case(const struct aws_byte_cursor *cursor, 
 }
 
 int aws_byte_buf_append(struct aws_byte_buf *to, const struct aws_byte_cursor *from) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(to));
-    AWS_PRECONDITION(aws_byte_cursor_is_valid(from));
+    AWS_PRECONDITION(aws_byte_buf_is_valid(to), "Input byte_buf [to] must be valid.");
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(from), "Input byte_cursor [from] must be valid.");
 
     if (to->capacity - to->len < from->len) {
         AWS_POSTCONDITION(aws_byte_buf_is_valid(to));
@@ -447,9 +447,10 @@ int aws_byte_buf_append_with_lookup(
     struct aws_byte_buf *AWS_RESTRICT to,
     const struct aws_byte_cursor *AWS_RESTRICT from,
     const uint8_t *lookup_table) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(to));
-    AWS_PRECONDITION(aws_byte_cursor_is_valid(from));
-    AWS_PRECONDITION(AWS_MEM_IS_READABLE(lookup_table, 256));
+    AWS_PRECONDITION(aws_byte_buf_is_valid(to), "Input byte_buf [to] must be valid.");
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(from), "Input byte_cursor [from] must be valid.");
+    AWS_PRECONDITION(
+        AWS_MEM_IS_READABLE(lookup_table, 256), "Input array [lookup_table] must be at least 256 bytes long.");
 
     if (to->capacity - to->len < from->len) {
         AWS_POSTCONDITION(aws_byte_buf_is_valid(to));
@@ -471,8 +472,8 @@ int aws_byte_buf_append_with_lookup(
 }
 
 int aws_byte_buf_append_dynamic(struct aws_byte_buf *to, const struct aws_byte_cursor *from) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(to));
-    AWS_PRECONDITION(aws_byte_cursor_is_valid(from));
+    AWS_PRECONDITION(aws_byte_buf_is_valid(to), "Input byte_buf [to] must be valid.");
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(from), "Input byte_cursor [from] must be valid.");
     if (!to->allocator) {
         return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
     }

--- a/source/common.c
+++ b/source/common.c
@@ -74,7 +74,7 @@ void *aws_mem_acquire(struct aws_allocator *allocator, size_t size) {
 }
 
 void *aws_mem_calloc(struct aws_allocator *allocator, size_t num, size_t size) {
-    AWS_PRECONDITION(allocator);
+    AWS_PRECONDITION(allocator, "Input pointer [allocator] mustn't be NULL.");
 
     /* Defensive check: never use calloc with size * num that would overflow
      * https://wiki.sei.cmu.edu/confluence/display/c/MEM07-C.+Ensure+that+the+arguments+to+calloc%28%29%2C+when+multiplied%2C+do+not+wrap

--- a/source/encoding.c
+++ b/source/encoding.c
@@ -88,8 +88,8 @@ int aws_hex_compute_encoded_len(size_t to_encode_len, size_t *encoded_length) {
 }
 
 int aws_hex_encode(const struct aws_byte_cursor *AWS_RESTRICT to_encode, struct aws_byte_buf *AWS_RESTRICT output) {
-    AWS_PRECONDITION(aws_byte_cursor_is_valid(to_encode));
-    AWS_PRECONDITION(aws_byte_buf_is_valid(output));
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(to_encode), "Input byte_cursor [to_encode] must be valid.");
+    AWS_PRECONDITION(aws_byte_buf_is_valid(output), "Input byte_buf [output] must be valid.");
 
     size_t encoded_len = 0;
 
@@ -174,8 +174,8 @@ int aws_hex_compute_decoded_len(size_t to_decode_len, size_t *decoded_len) {
 }
 
 int aws_hex_decode(const struct aws_byte_cursor *AWS_RESTRICT to_decode, struct aws_byte_buf *AWS_RESTRICT output) {
-    AWS_PRECONDITION(aws_byte_cursor_is_valid(to_decode));
-    AWS_PRECONDITION(aws_byte_buf_is_valid(output));
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(to_decode), "Input byte_cursor [to_decode] must be valid.");
+    AWS_PRECONDITION(aws_byte_buf_is_valid(output), "Input byte_buf [output] must be valid.");
 
     size_t decoded_length = 0;
 

--- a/source/hash_table.c
+++ b/source/hash_table.c
@@ -53,10 +53,10 @@ static uint64_t s_hash_for(struct hash_table_state *state, const void *key) {
 }
 
 static size_t s_index_for(struct hash_table_state *map, struct hash_table_entry *entry) {
-    AWS_PRECONDITION(hash_table_state_is_valid(map));
+    AWS_PRECONDITION(hash_table_state_is_valid(map), "Input hash_table_state [map] must be valid.");
     size_t index = entry - map->slots;
     AWS_POSTCONDITION(index < map->size);
-    AWS_PRECONDITION(hash_table_state_is_valid(map));
+    AWS_POSTCONDITION(hash_table_state_is_valid(map));
     return index;
 }
 
@@ -195,7 +195,10 @@ int aws_hash_table_init(
     aws_hash_callback_eq_fn *equals_fn,
     aws_hash_callback_destroy_fn *destroy_key_fn,
     aws_hash_callback_destroy_fn *destroy_value_fn) {
-    AWS_PRECONDITION(map && alloc && hash_fn && equals_fn);
+    AWS_PRECONDITION(map, "Input pointer [map] mustn't be NULL.");
+    AWS_PRECONDITION(alloc, "Input pointer [alloc] mustn't be NULL.");
+    AWS_PRECONDITION(hash_fn, "Input pointer [hash_fn] mustn't be NULL.");
+    AWS_PRECONDITION(equals_fn, "Input pointer [equals_fn] mustn't be NULL.");
 
     struct hash_table_state template;
     template.hash_fn = hash_fn;
@@ -235,14 +238,18 @@ void aws_hash_table_clean_up(struct aws_hash_table *map) {
 }
 
 void aws_hash_table_swap(struct aws_hash_table *AWS_RESTRICT a, struct aws_hash_table *AWS_RESTRICT b) {
-    AWS_PRECONDITION(a != b);
+    AWS_PRECONDITION(a != b, "Input hash_tables [a] and [b] must be different.");
     struct aws_hash_table tmp = *a;
     *a = *b;
     *b = tmp;
 }
 
 void aws_hash_table_move(struct aws_hash_table *AWS_RESTRICT to, struct aws_hash_table *AWS_RESTRICT from) {
-    AWS_PRECONDITION(to != NULL && from != NULL && to != from && aws_hash_table_is_valid(from));
+    AWS_PRECONDITION(to, "Input pointer [to] mustn't be NULL.");
+    AWS_PRECONDITION(from, "Input pointer [from] mustn't be NULL.");
+    AWS_PRECONDITION(to != from, "Input pointers [to] and [from] mustn't be aliased.");
+    AWS_PRECONDITION(aws_hash_table_is_valid(from), "Input hash_table [from] must be valid.");
+
     *to = *from;
     AWS_ZERO_STRUCT(*from);
     AWS_POSTCONDITION(aws_hash_table_is_valid(to));
@@ -522,9 +529,11 @@ int aws_hash_table_put(struct aws_hash_table *map, const void *key, void *value,
  * lower than the original entry's index)
  */
 static size_t s_remove_entry(struct hash_table_state *state, struct hash_table_entry *entry) {
-    AWS_PRECONDITION(hash_table_state_is_valid(state));
-    AWS_PRECONDITION(state->entry_count > 0);
-    AWS_PRECONDITION(entry >= &state->slots[0] && entry < &state->slots[state->size]);
+    AWS_PRECONDITION(hash_table_state_is_valid(state), "Input hash_table_state [state] must be valid.");
+    AWS_PRECONDITION(state->entry_count > 0, "Input hash_table_state [state] must contain at least one entry.");
+    AWS_PRECONDITION(
+        entry >= &state->slots[0] && entry < &state->slots[state->size],
+        "Input hash_table_entry [entry] pointer must point in the available slots.");
     state->entry_count--;
 
     /* Shift subsequent entries back until we find an entry that belongs at its
@@ -661,7 +670,8 @@ bool aws_hash_table_eq(
  * iterator which is "done".
  */
 static inline void s_get_next_element(struct aws_hash_iter *iter, size_t start_slot) {
-    AWS_PRECONDITION(iter != NULL);
+    AWS_PRECONDITION(iter != NULL, "Input pointer [iter] mustn't be NULL.");
+    AWS_PRECONDITION(aws_hash_table_is_valid(iter->map), "The hash_table pointed by input [iter] must be valid.");
     struct hash_table_state *state = iter->map->p_impl;
     size_t limit = iter->limit;
 
@@ -683,7 +693,7 @@ static inline void s_get_next_element(struct aws_hash_iter *iter, size_t start_s
 }
 
 struct aws_hash_iter aws_hash_iter_begin(const struct aws_hash_table *map) {
-    AWS_PRECONDITION(aws_hash_table_is_valid(map));
+    AWS_PRECONDITION(aws_hash_table_is_valid(map), "Input hash_table [map] must be valid.");
     struct hash_table_state *state = map->p_impl;
     struct aws_hash_iter iter;
     iter.map = map;
@@ -695,8 +705,10 @@ struct aws_hash_iter aws_hash_iter_begin(const struct aws_hash_table *map) {
 }
 
 bool aws_hash_iter_done(const struct aws_hash_iter *iter) {
-    AWS_PRECONDITION(aws_hash_iter_is_valid(iter));
-    AWS_PRECONDITION(iter->status == AWS_HASH_ITER_STATUS_DONE || iter->status == AWS_HASH_ITER_STATUS_READY_FOR_USE);
+    AWS_PRECONDITION(aws_hash_iter_is_valid(iter), "Input hash_iter [iter] must be valid.");
+    AWS_PRECONDITION(
+        iter->status == AWS_HASH_ITER_STATUS_DONE || iter->status == AWS_HASH_ITER_STATUS_READY_FOR_USE,
+        "Input hash_iter [iter] must either be done, or ready to use.");
     /*
      * SIZE_MAX is a valid (non-terminal) value for iter->slot in the event that
      * we delete slot 0. See comments in aws_hash_iter_delete.
@@ -711,7 +723,7 @@ bool aws_hash_iter_done(const struct aws_hash_iter *iter) {
 }
 
 void aws_hash_iter_next(struct aws_hash_iter *iter) {
-    AWS_PRECONDITION(aws_hash_iter_is_valid(iter));
+    AWS_PRECONDITION(aws_hash_iter_is_valid(iter), "Input hash_iter [iter] must be valid.");
 #pragma CPROVER check push
 #pragma CPROVER check disable "unsigned-overflow"
     s_get_next_element(iter, iter->slot + 1);
@@ -721,9 +733,12 @@ void aws_hash_iter_next(struct aws_hash_iter *iter) {
 }
 
 void aws_hash_iter_delete(struct aws_hash_iter *iter, bool destroy_contents) {
-    AWS_PRECONDITION(iter->status == AWS_HASH_ITER_STATUS_READY_FOR_USE);
-    AWS_PRECONDITION(aws_hash_iter_is_valid(iter));
-    AWS_PRECONDITION(iter->map->p_impl->entry_count > 0);
+    AWS_PRECONDITION(
+        iter->status == AWS_HASH_ITER_STATUS_READY_FOR_USE, "Input hash_iter [iter] must be ready for use.");
+    AWS_PRECONDITION(aws_hash_iter_is_valid(iter), "Input hash_iter [iter] must be valid.");
+    AWS_PRECONDITION(
+        iter->map->p_impl->entry_count > 0,
+        "The hash_table_state pointed by input [iter] must contain at least one entry.");
 
     struct hash_table_state *state = iter->map->p_impl;
     if (destroy_contents) {
@@ -849,8 +864,8 @@ uint64_t aws_hash_ptr(const void *item) {
 }
 
 bool aws_hash_callback_c_str_eq(const void *a, const void *b) {
-    AWS_PRECONDITION(aws_c_string_is_valid(a));
-    AWS_PRECONDITION(aws_c_string_is_valid(b));
+    AWS_PRECONDITION(aws_c_string_is_valid(a), "Input [a] must be a valid c_string.");
+    AWS_PRECONDITION(aws_c_string_is_valid(b), "Input [b] must be a valid c_string.");
     bool rval = !strcmp(a, b);
     AWS_POSTCONDITION(aws_c_string_is_valid(a));
     AWS_POSTCONDITION(aws_c_string_is_valid(b));
@@ -858,8 +873,8 @@ bool aws_hash_callback_c_str_eq(const void *a, const void *b) {
 }
 
 bool aws_hash_callback_string_eq(const void *a, const void *b) {
-    AWS_PRECONDITION(aws_string_is_valid(a));
-    AWS_PRECONDITION(aws_string_is_valid(b));
+    AWS_PRECONDITION(aws_string_is_valid(a), "Input [a] must be a valid c_string.");
+    AWS_PRECONDITION(aws_string_is_valid(b), "Input [b] must be a valid c_string.");
     bool rval = aws_string_eq(a, b);
     AWS_POSTCONDITION(aws_string_is_valid(a));
     AWS_POSTCONDITION(aws_string_is_valid(b));
@@ -867,7 +882,7 @@ bool aws_hash_callback_string_eq(const void *a, const void *b) {
 }
 
 void aws_hash_callback_string_destroy(void *a) {
-    AWS_PRECONDITION(aws_string_is_valid(a));
+    AWS_PRECONDITION(aws_string_is_valid(a), "Input [a] must be a valid c_string.");
     aws_string_destroy(a);
 }
 


### PR DESCRIPTION
Redefine `AWS_PRECONDITION` using `__CPROVER_precondition` so that it includes an explanation message.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
